### PR TITLE
Add support for syncing developer profile (Apple) type credentials.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,11 @@
         <artifactId>plain-credentials</artifactId>
         <version>1.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>xcode-plugin</artifactId>
+      <version>2.0.2</version>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -33,7 +33,7 @@ public class Constants {
     public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";
     public static final String OPENSHIFT_LABELS_BUILD_CONFIG_GIT_REPOSITORY_NAME = "openshift.io/gitRepository";
     // see PR https://github.com/openshift/jenkins-sync-plugin/pull/189, there was a issue with having "/"
-    // in a label we construct a watch over, where usual UTF-8 encoding of the label name (which becomes part of 
+    // in a label we construct a watch over, where usual UTF-8 encoding of the label name (which becomes part of
     // a query param on the REST invocation) was causing okhttp3 to complain (there is even more history/discussion
     // in the PR as to issues with fixing).
     // so we avoid use of "/" for this label
@@ -45,6 +45,7 @@ public class Constants {
     public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
     public static final String OPENSHIFT_SECRETS_DATA_FILENAME = "filename";
     public static final String OPENSHIFT_SECRETS_DATA_CERTIFICATE = "certificate";
+    public static final String OPENSHIFT_SECRETS_DATA_DEVELOPER_PROFILE = "developer-profile";
     public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
     public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
     public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";


### PR DESCRIPTION

**Verification:**

* Build and update to this version of the plugin in a running mobile CI/CD jenkins instance
* Retrieve an apple developer profile archive see "Allowing Jenkins to stage developer profile" section in https://wiki.jenkins.io/display/JENKINS/Xcode+Pluginhere 
* Create a new generic secret type using this developer profile and label for sync:

```
oc create secret generic ioscert --from-file=developer-profile=./mydeveloperprofile.developerprofile --from-literal=password=<password given when exporting>
oc label secret ioscert credential.sync.jenkins.openshift.io=true
```
* A new generic secret should be created in openshift, and a new Developer Profile type credential created in Jenkins.

**Jira:**

https://issues.jboss.org/browse/AEROGEAR-2656

**Note:** Opened here for review and verification purposes before opening upstream.